### PR TITLE
Do not force overwrite $ENV{ANSI_COLOR_DISABLED} in bin/pherkin

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -74,7 +74,7 @@ use warnings;
 use App::pherkin;
 
 BEGIN {
-    if ( not -t STDOUT ) {
+    if ( not -t STDOUT and not defined $ENV{'ANSI_COLORS_DISABLED'} ) {
         $ENV{'ANSI_COLORS_DISABLED'} = 1;
     }
 }


### PR DESCRIPTION
if STDOUT is not terminal.
Do it only if $ENV{ANSI_COLOR_DISABLED} is not defined.

So that it is possible write colorized output to pipe or output file,
for example:

 shell#> ANSI_COLOR_DISABLED=0 pherkin tests/* > colorized-output.txt