### PR TITLE
Refactor App::pherkin::run to better support parallel testing

### DIFF
--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -64,6 +64,12 @@ sub run {
       Test::BDD::Cucumber::Loader->load( $features_path, $self->tag_scheme );
     die "No feature files found in $features_path" unless @features;
 
+    return $self->_run_tests($executor, @features);
+}
+
+sub _run_tests {
+    my ( $self, $executor, @features ) = @_;
+
     my $harness = $self->harness;
     $harness->startup();
 

--- a/t/400_app_pherkin_harnesses.t
+++ b/t/400_app_pherkin_harnesses.t
@@ -16,12 +16,13 @@ use_ok("App::pherkin");
 
 for my $harness (@known_harnesses) {
     my $app    = App::pherkin->new();
-    my $object = $app->_load_harness($harness);
+    my $object = $app->_initialize_harness($harness);
     isa_ok(
         $object,
         "Test::BDD::Cucumber::Harness",
         "Loaded harness by name: [$harness] -> [" . ( ref $object ) . "]"
     );
+    is($app->harness, $object, "It is set to app->harness [$harness]");
 }
 
 done_testing();


### PR DESCRIPTION
Extract "initialization" & "run_tests" to separate methods for possible implement parallel run of tests simply by extending App::pherkin (with around method "_run_tests").