### PR TITLE
Shutdown harness gracefully

### DIFF
--- a/lib/Test/BDD/Cucumber/Manual/Integration.pod
+++ b/lib/Test/BDD/Cucumber/Manual/Integration.pod
@@ -39,7 +39,9 @@ test-suite. Luckily, this is SUPER easy.
 
  # For each feature found, execute it, using the Harness to print results
  $executor->execute( $_, $harness ) for @features;
- done_testing;
+ 
+ # Shutdown gracefully
+ $harness->shutdown();
 
 =cut
 


### PR DESCRIPTION
Existing example fails with the following error:

>Bareword "done_testing" not allowed while "strict subs" in use at <file>.
>Execution of <file> aborted due to compilation errors.